### PR TITLE
fix: reset after all people are chosen

### DIFF
--- a/react-client/src/PeoplePicker.jsx
+++ b/react-client/src/PeoplePicker.jsx
@@ -45,6 +45,10 @@ export function PeoplePicker() {
   )
 
   function chooseRandomPerson() {
+    if (unchosenPeople === 0) {
+      resetPeople();
+      return;
+    }
     let person = unchosenPeople[Math.floor(Math.random() * unchosenPeople.length)];
     setChosenPerson(person);
     setUnchosenPeople(unchosenPeople.filter(p => p !== person));
@@ -52,7 +56,6 @@ export function PeoplePicker() {
     console.log("chosen person is", person)
   }
   function resetPeople() {
-    fetchPeople();  
+    fetchPeople();
   }
 }
-

--- a/react-client/src/PeoplePicker.jsx
+++ b/react-client/src/PeoplePicker.jsx
@@ -7,17 +7,25 @@ export function PeoplePicker() {
   const [unchosenPeople, setUnchosenPeople] = useState([])
   const [chosenPeople, setChosenPeople] = useState([])
   useEffect(() => {
+    fetchPeople();
+  }, []);
+
+  function fetchPeople() {
     fetch('http://localhost:3001/api/people')
       .then(res => res.json())
-      .then(ppl => setUnchosenPeople(ppl))
-  }, [])
+      .then(ppl => {
+        setUnchosenPeople(ppl);
+        setChosenPeople([]);
+        setChosenPerson(null);
+      });
+  }
   return (
     <div className="PeoplePicker">
       <h1>People Picker</h1>
       <p className="alert info">Hit the choose button below to select a random person.</p>
       <div className="buttonRow">
         <button onClick={() => chooseRandomPerson()}>Choose</button>
-        <button className="link">Reset</button>
+        <button className="link" onClick={() => resetPeople()}>Reset</button>
       </div>
       <h2>Chosen Person</h2>
       <section className="chosenPerson">
@@ -42,6 +50,9 @@ export function PeoplePicker() {
     setUnchosenPeople(unchosenPeople.filter(p => p !== person));
     setChosenPeople([...chosenPeople, person])
     console.log("chosen person is", person)
+  }
+  function resetPeople() {
+    fetchPeople();  
   }
 }
 


### PR DESCRIPTION
This PR adds a fix that resets the people picker once all people have been chosen, preventing issues when trying to select from an empty list.

This PR builds on the changes made in PR #6, utilizing the resetPeople() function to handle the reset after all people have been selected.
